### PR TITLE
Move ejs dependency from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "ejs": "~0.8.3"
+  }
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1",
-    "ejs": "~0.8.3"
+    "grunt": "~0.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
Hi there,

In your task https://github.com/werk85/grunt-ng-constant/blob/master/tasks/ngconstant.js#L14  you have a dependency to `ejs` but you put it in `devDependencies`.

People that use your task and only have `grunt-ng-constant` in the `devDependencies` of their `package.json` won't be able to retrieve transitive dependency to `ejs`.
