### PR TITLE
Option for coffeescript output, switch deprecated grunt.util._ to lodash

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,23 @@ module.exports = function(grunt) {
           },
           'constant2': undefined
         }
-      }
+      },
+      coffee_options: [
+        {
+          options: {
+            coffee: true
+          },
+          dest: 'tmp/coffee_options.coffee',
+          name: 'module1',
+          constants: {
+            'constant1': {
+              key1: 'value1',
+              key2: 'value2'
+            },
+            'constant2': undefined
+          }
+        }
+      ]
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Optional
 
 A boolean to active or deactive the automatic wrapping. A string who will wrap the result of file, use the `<%= __ngModule %>` variable to indicate where to put the generated module content. See the "Custom Wrap Option" section for further informations.
 
+#### options.coffee
+Type: `Boolean`
+Default value: `false`
+Optional
+
+A boolean to toggle coffeescript output instead of javascript, using [`js2coffee`](https://github.com/rstacruz/js2coffee). Can also be assigned on a per-target basis.
 
 ### Usage Examples
 
@@ -69,6 +75,26 @@ grunt.initConfig({
   ngconstant: {
     dist: {
       dest: 'dist/constants.js',
+      name: 'constants',
+      constants: {
+        package: grunt.file.readJSON('package.json')
+      }
+    }
+  },
+})
+```
+
+#### Default Options, Coffeescript
+Same as above example, but outputs coffeescript instead
+
+```js
+grunt.initConfig({
+  ngconstant: {
+    options: {
+      coffee: true
+    },
+    dist: {
+      dest: 'dist/constants.coffee',
       name: 'constants',
       constants: {
         package: grunt.file.readJSON('package.json')

--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
     "constants",
     "module",
     "generator"
-  ]
+  ],
+  "dependencies": {
+    "js2coffee": "~0.2.3",
+    "lodash": "~2.2.1"
+  }
 }

--- a/tasks/ngconstant.js
+++ b/tasks/ngconstant.js
@@ -14,7 +14,7 @@ var DEFAULT_WRAP = '(function(angular, undefined) {\n\t <%= __ngModule %> \n})(a
 var TEMPLATE_PATH = path.join(__dirname, 'constant.tpl.ejs');
 
 module.exports = function (grunt) {
-  var _ = grunt.util._;
+  var _ = require('lodash');
 
   function toArray(value) {
     return _.isArray(value) ? value : [value];
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
       space: '\t',
       deps: [],
       wrap: false,
+      coffee: false,
       constants: {}
     });
     var template = grunt.file.read(TEMPLATE_PATH);
@@ -68,6 +69,12 @@ module.exports = function (grunt) {
         })
       });
 
+      // Javascript is built, convert to coffeescript if options.coffee
+      if(options.coffee || (module.options != null && module.options.coffee)) {
+        result = require('js2coffee').build(result);
+      }
+
+      // Write the module to disk
       grunt.file.write(module.dest, result);
       grunt.log.writeln('Module ' + module.name + ' created at ' + module.dest);
     });

--- a/test/expected/coffee_options.coffee
+++ b/test/expected/coffee_options.coffee
@@ -1,0 +1,5 @@
+angular.module("module1", []).constant("constant1",
+  key1: "value1"
+  key2: "value2"
+  global_key: "global_value"
+).constant "constant2", `undefined`

--- a/test/ngconstant_test.js
+++ b/test/ngconstant_test.js
@@ -68,4 +68,16 @@ exports.ng_constant = {
 
     test.done();
   },
+  coffee_options: function(test) {
+    test.expect(1);
+
+    // Was having whitespace problems
+    var actual = grunt.file.read('tmp/coffee_options.coffee').trim();
+    var expected = grunt.file.read('test/expected/coffee_options.coffee').trim();
+    test.equal(actual, expected, 'should output module in coffeescript');
+
+    test.done();
+  }
+    
+
 };


### PR DESCRIPTION
Coffeescript output is false by default, can be enabled with `options.coffee`. Uses `js2coffee` to convert the built javascript string to coffeescript before saving the file to disk.

Also, as per [Grunt's docs](http://gruntjs.com/api/grunt.util#grunt.util._-deprecated), using `grunt.util._` has been deprecated in favour of installing lodash or underscore through npm and saving it in `package.json`.
