### PR TITLE
Removed unused _.extend to grunt.config()

### DIFF
--- a/tasks/ngconstant.js
+++ b/tasks/ngconstant.js
@@ -72,9 +72,9 @@ module.exports = function (grunt) {
         wrap = DEFAULT_WRAP;
       }
       result = grunt.template.process(wrap, {
-        data: {
+        data: _.extend(grunt.config.getRaw(), {
           '__ngModule': result
-        }
+        })
       });
 
       // Javascript is built, convert to coffeescript


### PR DESCRIPTION
Tests passing.

Removed this _.extend() call in order to avoid errors on grunt when applying a custom wrap.

Error was: 

```
>> A special character was detected in this template. Inside template tags, the
>> \n and \r special characters must be escaped as \\n and \\r. (grunt 0.4.0+)
Warning: An error occurred while processing a template (Unexpected token ILLEGAL). Us
ed --force, continuing.
```
