### PR TITLE
Adds option for including global constants in specific modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,6 +116,28 @@ module.exports = function(grunt) {
           }
         }
       },
+	  global_constants_multiple_modules_options: [
+        {
+          dest: 'tmp/global_constants_multiple_modules_options_1.js',
+          name: 'module1',
+          constants: {
+            'constant2': {
+              global_key: 'value2'
+            }
+          },
+		  includeGlobalConstants: false
+        },
+        {
+          dest: 'tmp/global_constants_multiple_modules_options_2.js',
+          name: 'module2',
+          constants: {
+            'constant2': {
+              global_key: 'value2'
+            }
+          },
+		  includeGlobalConstants: true
+        }
+      ],
       coffee_options: [
         {
           dest: 'tmp/coffee_options.coffee',

--- a/README.md
+++ b/README.md
@@ -63,7 +63,14 @@ Type: `Object`
 Default value: `{}`
 Optional
 
-An object that gets automatically merged in all target `constants` definitions. When you use the multiple module option it gets merged in the first `constants` definition. This option should be used when you need a global `constants` definition for all your targets.
+An object that gets automatically merged in all target `constants` definitions. When you use the multiple module option, it gets merged into _only_ the first `constants` definition by default. This option should be used when you need a global `constants` definition for all your targets.
+
+#### options.includeGlobalConstants
+Type: `Boolean`
+Default value: `false`
+Optional
+
+A boolean that can be set on a specific module to indicate that global constants should be included in the module. Must be assigned on a per-module basis. 
 
 #### options.coffee
 Type: `Boolean`

--- a/tasks/ngconstant.js
+++ b/tasks/ngconstant.js
@@ -36,23 +36,24 @@ module.exports = function (grunt) {
     });
 
     // Pick all option variables which are available per module
-    var defaultModuleOptions = _.pick(options, ['space', 'deps', 'wrap', 'coffee', 'templatePath']);
+    var defaultModuleOptions = _.pick(options, ['space', 'deps', 'wrap', 'coffee', 'includeGlobalConstants', 'templatePath']);
 
-    // Get raw configurations for manuell wrap option interpolation
+    // Get raw configurations for manual wrap option interpolation
     var rawConfig = grunt.config.getRaw(this.name);
     var rawOptions = rawConfig && rawConfig.options || {};
     var rawData = toArray(rawConfig[this.target]);
 
-    // Merge global configuration in first module
     var modules = toArray(this.data);
-    if (modules.length) {
-      modules[0].constants = _.merge(options.constants, modules[0].constants);
-    }
 
     modules.forEach(function (module, index) {
       // Merge per module options with default options
       _.defaults(module, defaultModuleOptions);
 
+	  // Merge global configuration
+	  if (module.includeGlobalConstants || (module.includeGlobalConstants != false && index == 0)) {
+		module.constants = _.merge(options.constants, module.constants);
+	  };
+	  
       // Create compiler data
       var constants = _.map(module.constants, function (value, name) {
         return {

--- a/test/expected/global_constants_multiple_modules_options_1.js
+++ b/test/expected/global_constants_multiple_modules_options_1.js
@@ -1,0 +1,7 @@
+angular.module("module1", [])
+
+.constant("constant2", {
+	"global_key": "value2"
+})
+
+;;

--- a/test/expected/global_constants_multiple_modules_options_2.js
+++ b/test/expected/global_constants_multiple_modules_options_2.js
@@ -1,0 +1,11 @@
+angular.module("module2", [])
+
+.constant("constant1", {
+	"global_key": "global_value"
+})
+
+.constant("constant2", {
+	"global_key": "value2"
+})
+
+;;

--- a/test/ngconstant_test.js
+++ b/test/ngconstant_test.js
@@ -77,6 +77,24 @@ exports.ng_constant = {
 
     test.done();
   },
+  global_constants_multiple_modules_options_1: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/global_constants_multiple_modules_options_1.js');
+    var expected = grunt.file.read('test/expected/global_constants_multiple_modules_options_1.js');
+    test.equal(actual, expected, 'should not merge global constants when option is false.');
+
+    test.done();
+  },
+  global_constants_multiple_modules_options_2: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/global_constants_multiple_modules_options_2.js');
+    var expected = grunt.file.read('test/expected/global_constants_multiple_modules_options_2.js');
+    test.equal(actual, expected, 'should merge global constants when option is true.');
+
+    test.done();
+  },
   coffee_options: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
I came across a situation in which I needed to add global constants to multiple modules for different applications. In order to address that, I've added a new option for `includeGlobalConstants` that can be set at the module level to override the default of only including global constants to the first listed module. I've added two tests to verify and I believe this shouldn't introduce any breaking changes. 
