### PR TITLE
Support reading constants from file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,12 +137,17 @@ module.exports = function(grunt) {
         constants: {
           'constant1': 'value1'
         }
+      },
+      source_options: {
+        dest: 'tmp/source_options.js',
+        name: 'sourceOptionsModule',
+        constants_file: 'test/fixtures/constants.file.json'
       }
     },
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js'],
+      tests: ['test/*_test.js']
     },
 
     bump: {

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Optional
 
 An object that gets automatically merged in all target `constants` definitions. When you use the multiple module option it gets merged in the first `constants` definition. This option should be used when you need a global `constants` definition for all your targets.
 
+#### options.constants_file
+Type: `String`
+Default value: `null`
+Optional
+
+Relative path to JSON file containing constants. The contents of the specified file will be merged with any constants defined in options.constants
+
 #### options.coffee
 Type: `Boolean`
 Default value: `false`

--- a/tasks/ngconstant.js
+++ b/tasks/ngconstant.js
@@ -32,11 +32,12 @@ module.exports = function (grunt) {
       wrap: false,
       coffee: false,
       constants: {},
+      constants_file: null,
       templatePath: TEMPLATE_PATH
     });
 
     // Pick all option variables which are available per module
-    var defaultModuleOptions = _.pick(options, ['space', 'deps', 'wrap', 'coffee', 'templatePath']);
+    var defaultModuleOptions = _.pick(options, ['space', 'deps', 'wrap', 'coffee', 'templatePath', 'source']);
 
     // Get raw configurations for manuell wrap option interpolation
     var rawConfig = grunt.config.getRaw(this.name);
@@ -52,6 +53,23 @@ module.exports = function (grunt) {
     modules.forEach(function (module, index) {
       // Merge per module options with default options
       _.defaults(module, defaultModuleOptions);
+
+      // Read compiler data from file if source was set to 'file'
+      var fileConstants = null;
+      if (module.constants_file) {
+        var sourceFile = module.constants_file;
+        if (grunt.file.exists(sourceFile)) {
+          fileConstants = grunt.file.readJSON(sourceFile)
+        } else {
+          grunt.fail.fatal('source file does not exist in path [' + sourceFile + ']')
+        }
+      }
+
+
+      // Merge file constants with standard JSON constants
+      if (fileConstants) {
+        module.constants = _.merge(fileConstants, module.constants);
+      }
 
       // Create compiler data
       var constants = _.map(module.constants, function (value, name) {

--- a/test/expected/source_options.js
+++ b/test/expected/source_options.js
@@ -1,0 +1,9 @@
+angular.module("sourceOptionsModule", [])
+
+.constant("constant1", {
+	"key1": "value1",
+	"key2": "value2",
+	"global_key": "global_value"
+})
+
+;;

--- a/test/fixtures/constants.file.json
+++ b/test/fixtures/constants.file.json
@@ -1,0 +1,6 @@
+{
+  "constant1": {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}

--- a/test/ngconstant_test.js
+++ b/test/ngconstant_test.js
@@ -93,6 +93,14 @@ exports.ng_constant = {
       var expected = grunt.file.read('test/expected/template_options.js');
       test.equal(actual, expected, 'should output module with custom template');
       test.done();
+  },
+
+  source_options: function(test){
+    test.expect(1);
+    var actual = grunt.file.read('tmp/source_options.js');
+    var expected = grunt.file.read('test/expected/source_options.js');
+    test.equal(actual, expected, 'should read constants from file');
+    test.done();
   }
     
 


### PR DESCRIPTION
Currently the only way you can read constants from file is by using the grunt.file.readJSON utility method. This is fine as long as you configuration file is static and doesn't change during the lifecycle of the Grunt build process. That's not the case for us: we use mustache templates to dynamically generate constants based on external input.

Also, it's much simpler to just specify the file name be agnostic to the way the file is read.
