### PR TITLE
Add ability to specify 'dest' and 'name' as default options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,8 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     ngconstant: {
       options: {
+        dest: 'tmp/base_options.js',
+        name: 'module0',
         space: '\t',
         wrap: '<%= __ngModule %>;',
         constants: {
@@ -38,6 +40,9 @@ module.exports = function(grunt) {
             global_key: 'global_value'
           }
         }
+      },
+      base_settings: {
+        // intentionally blank to test that "dest" and "name" are inherited from options
       },
       default_options: [
         {

--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ Optional
 
 Location of a custom template file for creating the output configuration file. Defaults to the provided constants template file if none provided.
 
+#### options.dest
+Type: `String`
+Default value: `""`
+Optional
+
+Module destination. Useful if module is created in same destination for all environments.
+
+#### options.name
+Type: `String`
+Default value: `""`
+Optional
+
+Module name. For example, if name is 'moduleName':
+
+```js
+angular.module("moduleName", [])
+```
+
 ### Usage Examples
 
 #### Default Options
@@ -199,7 +217,7 @@ The resulting module looks like:
   "foobar": false
 })
 
-; 
+;
 })(angular);
 ```
 
@@ -236,7 +254,7 @@ grunt.initConfig({
 The resulting module looks like the following:
 
 ```
-define( ["angular", "ngResource", "ngCookies"], function() { 
+define( ["angular", "ngResource", "ngCookies"], function() {
  return angular.module("module2", ["test"])
 
 .constant("constant1", {
@@ -245,7 +263,7 @@ define( ["angular", "ngResource", "ngCookies"], function() {
   "foobar": false
 })
 
-; 
+;
 
 });
 ```

--- a/tasks/ngconstant.js
+++ b/tasks/ngconstant.js
@@ -32,11 +32,13 @@ module.exports = function (grunt) {
       wrap: false,
       coffee: false,
       constants: {},
-      templatePath: TEMPLATE_PATH
+      templatePath: TEMPLATE_PATH,
+      dest: '',
+      name: ''
     });
 
     // Pick all option variables which are available per module
-    var defaultModuleOptions = _.pick(options, ['space', 'deps', 'wrap', 'coffee', 'templatePath']);
+    var defaultModuleOptions = _.pick(options, ['space', 'deps', 'wrap', 'coffee', 'templatePath', 'dest', 'name']);
 
     // Get raw configurations for manuell wrap option interpolation
     var rawConfig = grunt.config.getRaw(this.name);

--- a/test/expected/base_options.js
+++ b/test/expected/base_options.js
@@ -1,0 +1,7 @@
+angular.module("module0", [])
+
+.constant("constant1", {
+	"global_key": "global_value"
+})
+
+;;

--- a/test/ngconstant_test.js
+++ b/test/ngconstant_test.js
@@ -23,6 +23,15 @@ var grunt = require('grunt');
 */
 
 exports.ng_constant = {
+  base_options: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/base_options.js');
+    var expected = grunt.file.read('test/expected/base_options.js');
+    test.equal(actual,expected,'should create a constants module with base settings');
+
+    test.done();
+  },
   default_options: function(test) {
     test.expect(1);
 
@@ -94,6 +103,6 @@ exports.ng_constant = {
       test.equal(actual, expected, 'should output module with custom template');
       test.done();
   }
-    
+
 
 };


### PR DESCRIPTION
For some applications, the 'dest' and 'name' may be the same across environments. I wanted the ability to secify these values once, rather than once per-environment.
