### PR TITLE
Angular 1.3 crashes from module syntax

### DIFF
--- a/tasks/ngconstant.js
+++ b/tasks/ngconstant.js
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask(MODULE_NAME, 'Dynamic angular constant generator task.', function () {
     var options = this.options({
-      deps: [],
+      deps: null,
       wrap: '{%= __ngModule %}',
       template: defaultTemplate,
       delimiters: MODULE_NAME,


### PR DESCRIPTION
This is the output i get from running the first example in the readme:
`angular.module('config', [])`
This crashes angular 1.3

Changing the empty deps array (which i can't see being used) to `null` I get:
`angular.module('config')`
Which angular likes.
