### PR TITLE
Using grunt getters when fetching config data

### DIFF
--- a/tasks/ngconstant.js
+++ b/tasks/ngconstant.js
@@ -101,7 +101,7 @@ module.exports = function (grunt) {
     }.bind(this);
 
     var result = grunt.template.process(options.template, {
-      data: _.extend({}, grunt.config.data, {
+      data: _.extend({}, grunt.config.get('data'), {
         moduleName: options.name,
         deps: options.deps,
         constants: transformData(options.constants),
@@ -116,7 +116,7 @@ module.exports = function (grunt) {
         options.wrap = DEFAULT_WRAP;
       }
       result = grunt.template.process(options.wrap, {
-        data: _.extend({}, grunt.config.data, {
+        data: _.extend({}, grunt.config.get('data'), {
           '__ngModule': result
         }),
         delimiters: options.delimiters


### PR DESCRIPTION
Variables within the 'constants' config block aren't being processed and interpolated because the config variable is being accessed directly instead of using grunt's config getters which automatically interpolate variables within the config object.